### PR TITLE
feat(fuckornot): 更新LLM调用方式并优化错误处理

### DIFF
--- a/fuckornot/__init__.py
+++ b/fuckornot/__init__.py
@@ -27,7 +27,7 @@ from zhenxun.utils.http_utils import AsyncHttpx
 from zhenxun.utils.platform import PlatformUtils
 from zhenxun.utils.withdraw_manage import WithdrawManager
 
-from .prompt import fuckResponse, get_prompt
+from .prompt import FuckResponse, get_prompt
 
 __plugin_meta__ = PluginMetadata(
     name="上不上",
@@ -151,7 +151,7 @@ async def _(bot: Bot, event: Event, params: Arparma):
                     "image/jpeg",
                 ),
             ],
-            response_model=fuckResponse,
+            response_model=FuckResponse,
             model=provider,
             instruction=prompt,
         )
@@ -177,7 +177,6 @@ async def _(bot: Bot, event: Event, params: Arparma):
                 time=withdraw_time,
             )
     except LLMException as le:
-        raise le
         logger.error(f"评分失败...\n{le.message}\n{le.details}", "fuckornot", e=le)
         receipt = await UniMessage(
             f"评分失败，请稍后再试.\n错误信息: {le.message}"

--- a/fuckornot/__init__.py
+++ b/fuckornot/__init__.py
@@ -16,21 +16,18 @@ from nonebot_plugin_alconna import (
 )
 from nonebot_plugin_alconna.uniseg.tools import reply_fetch
 from nonebot_plugin_htmlrender import template_to_pic
-import ujson
 
 from zhenxun.configs.config import Config
 from zhenxun.configs.utils import PluginExtraData, RegisterConfig
-from zhenxun.services.llm import get_model_instance
-from zhenxun.services.llm.config.generation import (
-    LLMGenerationConfig,
-)
-from zhenxun.services.llm.types.content import LLMContentPart, LLMMessage
+from zhenxun.services.llm import generate_structured
+from zhenxun.services.llm.types.content import LLMContentPart
+from zhenxun.services.llm.types.exceptions import LLMException
 from zhenxun.services.log import logger
 from zhenxun.utils.http_utils import AsyncHttpx
 from zhenxun.utils.platform import PlatformUtils
 from zhenxun.utils.withdraw_manage import WithdrawManager
 
-from .prompt import get_prompt
+from .prompt import fuckResponse, get_prompt
 
 __plugin_meta__ = PluginMetadata(
     name="上不上",
@@ -59,7 +56,7 @@ __plugin_meta__ = PluginMetadata(
     """.strip(),
     extra=PluginExtraData(
         author="molanp",
-        version="1.7",
+        version="1.8",
         menu_type="群内小游戏",
         configs=[
             RegisterConfig(
@@ -119,7 +116,7 @@ fuck = on_alconna(
 
 
 @fuck.handle()
-async def _(bot: Bot, event: Event,params: Arparma):
+async def _(bot: Bot, event: Event, params: Arparma):
     base_config = Config.get("fuckornot")
     image = params.query("image") or await reply_fetch(event, bot)
     soul = params.query("soul") or base_config.get("default_soul")
@@ -142,68 +139,22 @@ async def _(bot: Bot, event: Event,params: Arparma):
         return
     if not image_bytes:
         await UniMessage("下载图片失败QAQ...").finish(reply_to=True)
-    data = {}
     provider = base_config.get("provider")
     preview = base_config.get("preview")
     preview_src = base64.b64encode(image_bytes).decode("utf-8") if preview else ""
-
-    model_config = LLMGenerationConfig(
-        response_mime_type="application/json",
-        response_schema={
-            "type": "OBJECT",
-            "properties": {
-                "verdict": {
-                    "type": "STRING",
-                    "description": "'上' 或 '不上'",
-                },
-                "rating": {
-                    "type": "STRING",
-                    "description": "1到10的数字",
-                },
-                "explanation": {
-                    "type": "STRING",
-                    "description": "你的评语/解释",
-                },
-            },
-            "nullable": False,
-            "required": ["verdict", "rating", "explanation"],
-        },
-        # safety_settings={
-        #     "HARM_CATEGORY_HARASSMENT": "BLOCK_NONE",
-        #     "HARM_CATEGORY_HATE_SPEECH": "BLOCK_NONE",
-        #     "HARM_CATEGORY_SEXUALLY_EXPLICIT": "BLOCK_NONE",
-        #     "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_NONE",
-        #     "HARM_CATEGORY_CIVIC_INTEGRITY": "BLOCK_NONE",
-        # },
-    )
     try:
-        async with await get_model_instance(provider) as model:
-            response = await model.generate_response(
-                messages=[
-                    LLMMessage.system(content=prompt),
-                    LLMMessage.user(
-                        [
-                            LLMContentPart.text_part("开始游戏。请评估这张艺术品"),
-                            LLMContentPart.image_base64_part(
-                                base64.b64encode(image_bytes).decode("utf-8"),
-                                "image/jpeg",
-                            ),
-                        ]
-                    ),
-                ],
-                config=model_config,
-            )
-            data = response.raw_response or {}
-        res = data["candidates"][0]["content"]["parts"][0]["text"]
-        if "`" in res:
-            res = res.replace("`", "")
-        if "json" in res:
-            res = res.replace("json", "")
-        if "\n" in res:
-            res = res.replace("\n", "")
-        if r"\n" in res:
-            res = res.replace(r"\n", "")
-        data: dict = ujson.loads(res)
+        response = await generate_structured(
+            message=[
+                LLMContentPart.text_part("开始游戏。请评估这张艺术品"),
+                LLMContentPart.image_base64_part(
+                    base64.b64encode(image_bytes).decode("utf-8"),
+                    "image/jpeg",
+                ),
+            ],
+            response_model=fuckResponse,
+            model=provider,
+            instruction=prompt,
+        )
 
         receipt = await UniMessage(
             Image(
@@ -211,9 +162,9 @@ async def _(bot: Bot, event: Event,params: Arparma):
                     str(Path(__file__).parent),
                     "result.html",
                     templates={
-                        "verdict": data["verdict"],
-                        "rating": data["rating"],
-                        "explanation": data["explanation"],
+                        "verdict": response.verdict,
+                        "rating": response.rating,
+                        "explanation": response.explanation,
                         "src": preview_src,
                     },
                 )
@@ -225,21 +176,9 @@ async def _(bot: Bot, event: Event,params: Arparma):
                 receipt.msg_ids[0]["message_id"],
                 time=withdraw_time,
             )
-
-    except Exception as e:
-        logger.error(f"评分失败...\n{data}", "fuckornot", e=e)
-        error_msg = data.get("candidates", [{}])[0].get("finishReason")
-        if error_msg:
-            receipt = await UniMessage(
-                f"评分失败，请稍后再试.\n错误信息: {error_msg}"
-            ).send(reply_to=True)
-        else:
-            receipt = await UniMessage(
-                f"评分失败，请稍后再试.\n错误信息: {type(e)}"
-            ).send(reply_to=True)
-        if withdraw_time > 0:
-            await WithdrawManager.withdraw_message(
-                bot,
-                receipt.msg_ids[0]["message_id"],
-                time=withdraw_time,
-            )
+    except LLMException as le:
+        raise le
+        logger.error(f"评分失败...\n{le.message}\n{le.details}", "fuckornot", e=le)
+        receipt = await UniMessage(
+            f"评分失败，请稍后再试.\n错误信息: {le.message}"
+        ).send(reply_to=True)

--- a/fuckornot/prompt.py
+++ b/fuckornot/prompt.py
@@ -33,7 +33,7 @@ def get_prompt(s: str | int):
         return prompt[soul_list[s]]
 
 
-class fuckResponse(BaseModel):
+class FuckResponse(BaseModel):
     verdict: Literal["上", "不上"] = Field(..., description="'上' 或 '不上'")
     rating: int = Field(..., description="1到10的数字")
     explanation: str = Field(..., description="你的评语/解释")

--- a/fuckornot/prompt.py
+++ b/fuckornot/prompt.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from pydantic import BaseModel, Field
+from typing import Literal
 import ujson
 
 soul_list = {
@@ -33,6 +34,6 @@ def get_prompt(s: str | int):
 
 
 class fuckResponse(BaseModel):
-    verdict: str = Field(..., description="'上' 或 '不上'")
-    rating: str = Field(..., description="1到10的数字")
+    verdict: Literal["上", "不上"] = Field(..., description="'上' 或 '不上'")
+    rating: int = Field(..., description="1到10的数字")
     explanation: str = Field(..., description="你的评语/解释")

--- a/fuckornot/prompt.py
+++ b/fuckornot/prompt.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from pydantic import BaseModel, Field
 import ujson
 
 soul_list = {
@@ -22,10 +23,16 @@ prompt: dict[str, str] = ujson.loads(
 
 def get_prompt(s: str | int):
     if isinstance(s, int) and not 0 < s <= len(soul_list):
-        raise ValueError(f"人格 {s} 不存在！")
+        raise ValueError("人格不存在！")
     if isinstance(s, str) and s not in soul_list.keys():
-        raise ValueError(f"人格 {s} 不存在！")
+        raise ValueError("人格不存在！")
     if isinstance(s, int):
         return prompt[list(soul_list.values())[s - 1]]
     else:
         return prompt[soul_list[s]]
+
+
+class fuckResponse(BaseModel):
+    verdict: str = Field(..., description="'上' 或 '不上'")
+    rating: str = Field(..., description="1到10的数字")
+    explanation: str = Field(..., description="你的评语/解释")


### PR DESCRIPTION
- 移除对ujson的直接依赖，改用generate_structured进行结构化响应生成
- 引入fuckResponse模型用于定义LLM输出结构
- 简化LLM调用逻辑，移除冗余的response解析步骤
- 使用LLMException捕获LLM相关异常，提升错误提示可读性
- 升级插件版本至1.8
- 优化代码格式与导入顺序

## Sourcery 总结

将 LLM 响应的手动 JSON 解析替换为使用 pydantic 模型进行结构化生成，改进错误处理，提升版本，并清理代码。

新功能：
- 引入基于 pydantic 的 `fuckResponse` 模型来定义 LLM 输出模式
- 切换到 `generate_structured` 以获取结构化的 LLM 响应，而不是手动解析

改进：
- 移除 ujson 依赖和冗余的响应解析逻辑
- 使用 `LLMException` 来捕获和处理 LLM 错误，并提供更清晰的消息
- 简化 LLM 交互流程
- 将插件版本提升到 1.8
- 优化代码格式和导入顺序

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使用 pydantic 模型将手动 LLM 响应解析替换为结构化生成，并改进错误处理。

新功能：
- 引入 `FuckResponse` pydantic 模型以定义 LLM 输出 schema
- 改用 `generate_structured` 进行 LLM 调用，而不是手动 JSON 解析

改进：
- 移除直接的 `ujson` 依赖和冗余的响应清理逻辑
- 使用 `LLMException` 来捕获和显示 LLM 错误，并附带更清晰的消息
- 将插件版本提升至 1.8 并整理导入顺序

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace manual LLM response parsing with structured generation using a pydantic model and improve error handling

New Features:
- Introduce the `FuckResponse` pydantic model to define LLM output schema
- Switch to `generate_structured` for LLM calls instead of manual JSON parsing

Enhancements:
- Remove direct `ujson` dependency and redundant response-cleaning logic
- Use `LLMException` to catch and display LLM errors with clearer messages
- Bump plugin version to 1.8 and tidy up import order

</details>

</details>